### PR TITLE
[Deps] move `evalmd` to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 		"define-properties": "^1.1.3",
 		"es-abstract": "^1.19.1",
 		"es-aggregate-error": "^1.0.7",
-		"evalmd": "^0.0.19",
 		"get-intrinsic": "^1.1.1",
 		"globalthis": "^1.0.2"
 	},
@@ -101,6 +100,7 @@
 		"aud": "^1.1.5",
 		"auto-changelog": "^2.3.0",
 		"eslint": "^7.32.0",
+		"evalmd": "^0.0.19",
 		"function.prototype.name": "^1.1.5",
 		"has-strict-mode": "^1.0.1",
 		"nyc": "^10.3.2",


### PR DESCRIPTION
It seems like `evalmd` is only used for development.